### PR TITLE
Add support for protocol version J2602_1_1.0

### DIFF
--- a/ldfparser/grammar.py
+++ b/ldfparser/grammar.py
@@ -72,7 +72,7 @@ class LdfTransformer(Transformer):
         return ("nodes", {'master': tree[0], 'slaves': tree[1]})
 
     def nodes_master(self, tree):
-        return {"name": tree[0], "timebase": tree[1] * 0.001, "jitter": tree[2] * 0.001}
+        return {"name": tree[0], "timebase": tree[1] * 0.001, "jitter": tree[2] * 0.001, "max_header_length": tree[3] if len(tree) > 3 else None, "response_tolerance": tree[4] * 0.01 if len(tree) > 4 else None}
 
     def nodes_slaves(self, tree):
         return tree
@@ -200,6 +200,9 @@ class LdfTransformer(Transformer):
 
     def node_definition_configurable_frames_21(self, tree):
         return ("configurable_frames", tree[0:])
+
+    def node_definition_response_tolerance(self, tree):
+        return ("response_tolerance", tree[0] * 0.01)
 
     def schedule_tables(self, tree):
         return ("schedule_tables", tree)

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -3,7 +3,7 @@ start: ldf
 ldf: (header_lin_description_file | header_protocol_version | header_language_version | header_speed | header_channel | header_file_revision | header_sig_byte_order_big_endian | header_sig_byte_order_little_endian | nodes | node_compositions | signals | diagnostic_signals | diagnostic_addresses | frames | sporadic_frames | event_triggered_frames | diagnostic_frames | node_attributes | schedule_tables | signal_groups | signal_encoding_types | signal_representations)*
 
 ldf_identifier: CNAME
-ldf_version: LIN_VERSION | ISO_VERSION
+ldf_version: LIN_VERSION | ISO_VERSION | J2602_VERSION
 ldf_integer: C_INT
 ldf_float: C_FLOAT
 ldf_channel_name: ESCAPED_STRING
@@ -21,8 +21,9 @@ header_sig_byte_order_big_endian: "LIN_sig_byte_order_big_endian" ";"
 header_sig_byte_order_little_endian: "LIN_sig_byte_order_little_endian" ";"
 
 // LIN 2.1 Specification, section 9.2.2
+// SAE J2602-3_201001, SECTION 7.2
 nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
-nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ";"
+nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_integer "%")* ";"
 nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 
 // LIN 2.1 Specification, section 9.2.2.3
@@ -66,8 +67,9 @@ diagnostic_addresses: "Diagnostic_addresses" "{" (diagnostic_address)* "}"
 diagnostic_address: ldf_identifier ":" ldf_integer ";"
 
 // LIN 2.1 Specification, section 9.2.2.2
+// response_tolerance: SAE J2602_1_201001, section 7.2.1
 node_attributes: "Node_attributes" "{" (node_definition*) "}"
-node_definition: ldf_identifier "{" (node_definition_protocol | node_definition_configured_nad | node_definition_initial_nad | node_definition_product_id | node_definition_response_error | node_definition_fault_state_signals | node_definition_p2_min | node_definition_st_min | node_definition_n_as_timeout | node_definition_n_cr_timeout | node_definition_configurable_frames)* "}"
+node_definition: ldf_identifier "{" (node_definition_protocol | node_definition_configured_nad | node_definition_initial_nad | node_definition_product_id | node_definition_response_error | node_definition_fault_state_signals | node_definition_p2_min | node_definition_st_min | node_definition_n_as_timeout | node_definition_n_cr_timeout | node_definition_configurable_frames | node_definition_response_tolerance)* "}"
 node_definition_protocol: "LIN_protocol" "=" (["\"" ldf_version "\""] | ldf_version) ";"
 node_definition_configured_nad: "configured_NAD" "=" ldf_integer ";"
 node_definition_initial_nad: "initial_NAD" "=" ldf_integer ";"
@@ -81,6 +83,8 @@ node_definition_n_cr_timeout: "N_Cr_timeout" "=" ldf_float "ms" ";"
 node_definition_configurable_frames: node_definition_configurable_frames_20 | node_definition_configurable_frames_21
 node_definition_configurable_frames_20: "configurable_frames" "{" (ldf_identifier "=" ldf_integer ";")+ "}"
 node_definition_configurable_frames_21: "configurable_frames" "{" (ldf_identifier ";")+ "}"
+node_definition_response_tolerance: "response_tolerance" "=" ldf_float "%" ";"
+
 
 // LIN 2.1 Specification, section 9.2.5
 schedule_tables: "Schedule_tables" "{" (schedule_table_definition+) "}" 
@@ -120,6 +124,7 @@ C_INT: ("0x"HEXDIGIT+) | ("-"? INT)
 C_FLOAT: ("-"? INT ("." INT)?) ("e" ("+" | "-")? INT)?
 LIN_VERSION: INT "." INT
 ISO_VERSION: "ISO17987" ":" INT
+J2602_VERSION: "J2602" "_" INT "_" INT "." INT
 
 ANY_SEMICOLON_TERMINATED_LINE: /.*;/
 

--- a/ldfparser/grammars/ldf.lark
+++ b/ldfparser/grammars/ldf.lark
@@ -23,7 +23,7 @@ header_sig_byte_order_little_endian: "LIN_sig_byte_order_little_endian" ";"
 // LIN 2.1 Specification, section 9.2.2
 // SAE J2602-3_201001, SECTION 7.2
 nodes: "Nodes" "{" nodes_master? nodes_slaves? "}"
-nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_integer "%")* ";"
+nodes_master: "Master" ":" ldf_identifier "," ldf_float "ms" "," ldf_float "ms" ("," ldf_integer "bits" "," ldf_float "%")* ";"
 nodes_slaves: "Slaves" ":" ldf_identifier ("," ldf_identifier)* ";"
 
 // LIN 2.1 Specification, section 9.2.2.3

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -3,7 +3,7 @@ Lin Description File handler objects
 """
 from typing import Union, Dict, List
 
-from .lin import LinVersion, Iso17987Version, J2602_BASE
+from .lin import LinVersion, Iso17987Version
 from .frame import LinFrame, LinSporadicFrame, LinUnconditionalFrame, LinEventTriggeredFrame
 from .diagnostics import LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
 from .signal import LinSignal
@@ -407,6 +407,3 @@ class LDF():
         Deprecated, use `get_slave` instead, this method will be removed in 1.0.0
         """
         return self._slaves.get(name)
-
-    def is_j2602_protocol(self):
-        return J2602_BASE in self._protocol_version

--- a/ldfparser/ldf.py
+++ b/ldfparser/ldf.py
@@ -3,7 +3,7 @@ Lin Description File handler objects
 """
 from typing import Union, Dict, List
 
-from .lin import LinVersion, Iso17987Version
+from .lin import LinVersion, Iso17987Version, J2602_BASE
 from .frame import LinFrame, LinSporadicFrame, LinUnconditionalFrame, LinEventTriggeredFrame
 from .diagnostics import LinDiagnosticFrame, LinDiagnosticRequest, LinDiagnosticResponse
 from .signal import LinSignal
@@ -407,3 +407,6 @@ class LDF():
         Deprecated, use `get_slave` instead, this method will be removed in 1.0.0
         """
         return self._slaves.get(name)
+
+    def is_j2602_protocol(self):
+        return J2602_BASE in self._protocol_version

--- a/ldfparser/lin.py
+++ b/ldfparser/lin.py
@@ -3,6 +3,7 @@ Utility classes for LIN objects
 """
 from typing import Union
 
+
 class LinVersion:
     """
     LinVersion represents the LIN protocol and LDF language versions
@@ -118,6 +119,22 @@ class Iso17987Version:
 
 ISO17987_2015 = Iso17987Version(2015)
 
+
+J2602_BASE = "J2602_"
+def parse_j2602_version(version: str) -> Union[LinVersion, Iso17987Version]:
+    if J2602_BASE not in version:
+        raise ValueError(f'{version} is not an SAE J2602 version.')
+
+    version = version.replace("J2602_", '')
+    (_, versions) = version.split('_')
+    major = int(versions.split('.')[0])
+
+    if major == 1:
+        return LinVersion(2, 0)
+
+    raise ValueError(f'{version} is not supported yet.')
+
+
 def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
     try:
         return LinVersion.from_string(version)
@@ -125,4 +142,6 @@ def parse_lin_version(version: str) -> Union[LinVersion, Iso17987Version]:
         try:
             return Iso17987Version.from_string(version)
         except ValueError:
+            if J2602_BASE in version:
+                return parse_j2602_version(version)
             raise ValueError(f'{version} is not a valid LIN version.')

--- a/ldfparser/node.py
+++ b/ldfparser/node.py
@@ -78,10 +78,20 @@ class LinMaster(LinNode):
     :type jitter: float
     """
 
-    def __init__(self, name: str, timebase: float, jitter: float):
+    def __init__(
+            self,
+            name: str,
+            timebase: float,
+            jitter: float,
+            max_header_length: int,
+            response_tolerance: float,
+    ):
         super().__init__(name)
         self.timebase: float = timebase
         self.jitter: float = jitter
+        self.max_header_length: int = max_header_length
+        self.response_tolerance: float = response_tolerance
+
 
 class LinSlave(LinNode):
     """
@@ -124,6 +134,7 @@ class LinSlave(LinNode):
         self.n_as_timeout: float = 1
         self.n_cr_timeout: float = 1
         self.configurable_frames = {}
+        self.response_tolerance = 0.4
 
 class LinNodeCompositionConfiguration:
 

--- a/ldfparser/node.py
+++ b/ldfparser/node.py
@@ -134,7 +134,7 @@ class LinSlave(LinNode):
         self.n_as_timeout: float = 1
         self.n_cr_timeout: float = 1
         self.configurable_frames = {}
-        self.response_tolerance = 0.4
+        self.response_tolerance = None
 
 class LinNodeCompositionConfiguration:
 

--- a/tests/ldf/j2602_1.ldf
+++ b/tests/ldf/j2602_1.ldf
@@ -1,6 +1,4 @@
 /*
-* File: hello.ldf
-* Author: Christian Bondesson
 * Description: The LIN description file for the example program
 */
 

--- a/tests/ldf/j2602_1.ldf
+++ b/tests/ldf/j2602_1.ldf
@@ -1,0 +1,57 @@
+/*
+* File: hello.ldf
+* Author: Christian Bondesson
+* Description: The LIN description file for the example program
+*/
+
+LIN_description_file ;
+LIN_protocol_version = "J2602_1_1.0";
+LIN_language_version = "J2602_3_1.0";
+LIN_speed = 19.2 kbps;
+
+Nodes {
+    Master: CEM, 5 ms, 0.1 ms, 24 bits, 30% ;
+    Slaves: LSM;
+}
+
+Signals {
+    InternalLightsRequest: 2, 0, CEM, LSM;
+    InternalLightsSwitch: 2, 0, LSM, CEM;
+}
+
+Frames {
+    VL1_CEM_Frm1: 1, CEM {
+        InternalLightsRequest, 0;
+    }
+    VL1_LSM_Frm1: 2, LSM {
+        InternalLightsSwitch, 0;
+    }
+}
+
+Node_attributes {
+    LSM {
+        LIN_protocol = 2.0;
+        configured_NAD = 0x01;
+		response_tolerance = 38 % ;
+    }
+}
+
+Schedule_tables {
+    MySchedule1 {
+        VL1_CEM_Frm1 delay 15 ms;
+        VL1_LSM_Frm1 delay 15 ms;
+    }
+}
+
+Signal_encoding_types {
+    Dig2Bit {
+        logical_value, 0, "off";
+        logical_value, 1, "on";
+        logical_value, 2, "error";
+        logical_value, 3, "void";
+    }
+}
+
+Signal_representation {
+    Dig2Bit: InternalLightsRequest, InternalLightsSwitch;
+}

--- a/tests/ldf/j2602_1_no_values.ldf
+++ b/tests/ldf/j2602_1_no_values.ldf
@@ -1,0 +1,54 @@
+/*
+* Description: The LIN description file with J2602 protocol version, without the new attributes
+*/
+
+LIN_description_file ;
+LIN_protocol_version = "J2602_1_1.0";
+LIN_language_version = "J2602_3_1.0";
+LIN_speed = 10.417 kbps;
+
+Nodes {
+    Master: CEM, 5 ms, 0.1 ms;
+    Slaves: LSM;
+}
+
+Signals {
+    InternalLightsRequest: 2, 0, CEM, LSM;
+    InternalLightsSwitch: 2, 0, LSM, CEM;
+}
+
+Frames {
+    VL1_CEM_Frm1: 1, CEM {
+        InternalLightsRequest, 0;
+    }
+    VL1_LSM_Frm1: 2, LSM {
+        InternalLightsSwitch, 0;
+    }
+}
+
+Node_attributes {
+    LSM {
+        LIN_protocol = "J2602_1_1.0";
+        configured_NAD = 0x01;
+    }
+}
+
+Schedule_tables {
+    MySchedule1 {
+        VL1_CEM_Frm1 delay 15 ms;
+        VL1_LSM_Frm1 delay 15 ms;
+    }
+}
+
+Signal_encoding_types {
+    Dig2Bit {
+        logical_value, 0, "off";
+        logical_value, 1, "on";
+        logical_value, 2, "error";
+        logical_value, 3, "void";
+    }
+}
+
+Signal_representation {
+    Dig2Bit: InternalLightsRequest, InternalLightsSwitch;
+}

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -170,7 +170,18 @@ def test_linversion_from_j2602(value, expected):
     result = parse_lin_version(value)
     assert result.__class__ == expected.__class__
     assert result == expected
+    assert result.use_j2602
 
+@pytest.mark.parametrize(
+    'value',
+    [
+        '1.1',
+        '2.2',
+    ]
+)
+def test_linversion_j2602_default(value):
+    result = parse_lin_version(value)
+    assert not result.use_j2602
 
 @pytest.mark.parametrize(
     ('value'),

--- a/tests/test_lin.py
+++ b/tests/test_lin.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 import pytest
-from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version
+from ldfparser.lin import LIN_VERSION_1_3, LIN_VERSION_2_0, LIN_VERSION_2_1, LIN_VERSION_2_2, Iso17987Version, parse_lin_version, parse_j2602_version
 
 @pytest.mark.unit()
 @pytest.mark.parametrize(
@@ -156,3 +156,31 @@ def test_linversion_iso_invalid(a, b, op, exc):
 def test_linversion_parse_invalid(value):
     with pytest.raises(ValueError):
         parse_lin_version(value)
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('J2602_1_1.0', LIN_VERSION_2_0),
+        ('J2602_3_1.0', LIN_VERSION_2_0),
+        ('J2602_1_1.1', LIN_VERSION_2_0),
+    ]
+)
+def test_linversion_from_j2602(value, expected):
+    result = parse_lin_version(value)
+    assert result.__class__ == expected.__class__
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('value'),
+    [
+        '',
+        '1.2',
+        'ISO17987:2016',
+        'J2602_1_2.0'
+    ]
+)
+def test_linversion_unsupported_j2602(value):
+    with pytest.raises(ValueError):
+        parse_j2602_version(value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ from ldfparser.parser import parse_ldf
 from ldfparser.frame import LinFrame
 from ldfparser.signal import LinSignal
 from ldfparser.encoding import ASCIIValue, BCDValue, LogicalValue
-from ldfparser.lin import Iso17987Version
+from ldfparser.lin import Iso17987Version, LIN_VERSION_2_0
 
 @pytest.mark.unit
 def test_load_valid_lin13():
@@ -211,3 +211,23 @@ def test_load_iso17987():
 
     assert isinstance(ldf.get_language_version(), Iso17987Version)
     assert ldf.get_language_version().revision == 2015
+
+@pytest.mark.unit
+def test_load_j2602_attributes():
+    path = os.path.join(os.path.dirname(__file__), "ldf", "j2602_1.ldf")
+    ldf = parse_ldf(path)
+
+    assert ldf.get_protocol_version() == LIN_VERSION_2_0
+    assert ldf.get_language_version() == LIN_VERSION_2_0
+    assert ldf.master.max_header_length == 24
+    assert ldf.master.response_tolerance == 0.3
+    assert list(ldf.slaves)[0].response_tolerance == 0.38
+
+@pytest.mark.unit
+def test_default_j2602_attributes():
+    path = os.path.join(os.path.dirname(__file__), "ldf", "lin20.ldf")
+    ldf = parse_ldf(path)
+
+    assert ldf.master.max_header_length == 48
+    assert ldf.master.response_tolerance == 0.4
+    assert list(ldf.slaves)[0].response_tolerance == 0.4

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -223,11 +223,21 @@ def test_load_j2602_attributes():
     assert ldf.master.response_tolerance == 0.3
     assert list(ldf.slaves)[0].response_tolerance == 0.38
 
-@pytest.mark.unit
-def test_default_j2602_attributes():
-    path = os.path.join(os.path.dirname(__file__), "ldf", "lin20.ldf")
+@pytest.mark.parametrize(
+    'file, max_header_length, master_response_tolerance, slave_response_tolerance',
+    [
+        ("lin20.ldf", None, None, None),
+        ("j2602_1_no_values.ldf", 48, 0.4, 0.4)
+    ]
+)
+def test_j2602_attributes_default(
+        file, max_header_length, master_response_tolerance, slave_response_tolerance):
+    """
+    Should not set default value for J2602 attributes if protocol is not J2602
+    """
+    path = os.path.join(os.path.dirname(__file__), "ldf", file)
     ldf = parse_ldf(path)
 
-    assert ldf.master.max_header_length == 48
-    assert ldf.master.response_tolerance == 0.4
-    assert list(ldf.slaves)[0].response_tolerance == 0.4
+    assert ldf.master.max_header_length == max_header_length
+    assert ldf.master.response_tolerance == master_response_tolerance
+    assert list(ldf.slaves)[0].response_tolerance == slave_response_tolerance


### PR DESCRIPTION
## Brief

- Allow parsing of files with protocol version J2602_1_1.0, which is for J2602:2012 and earlier SAE J2602 protocols. 
- Add new attributes to the master frame and node attributes: `max_header_length` and `response_tolerance`

Note support for J2602_1_2.0(SAE J2602:2021) is not added due to the following reasons:
1.  J2602_1_2.0 renames the term “master” to “commander” and the term “slave” with “responder”, which may require bigger changes.
2. The project I'm working on uses the legacy version, and I don't have example LDF files for the new version.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [ ] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

+ Describe the bug or feature and link to relevant issues

## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Analyze how the change might impact existing code

+ Provide evidence that the feature is tested and covered properly
