### PR TITLE
Fix issue with decode/encode signals of list type

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -215,7 +215,7 @@ def frame():
         8: temp_signal,
         14: reserved1_signal,
         18: int_error_signal,
-        19: comm_error_signal,
+        19: comm_error_signal
     })
 
 @pytest.fixture(scope="function")

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -215,7 +215,7 @@ def frame():
         8: temp_signal,
         14: reserved1_signal,
         18: int_error_signal,
-        19: comm_error_signal
+        19: comm_error_signal,
     })
 
 @pytest.fixture(scope="function")
@@ -269,6 +269,47 @@ class TestLinUnconditionalFrameEncoding:
     def test_encode_error_type(self, frame, value):
         with pytest.raises(ValueError):
             frame.encode({'MotorSpeed': value})
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_converter", [True, False])
+def test_encode_decode_array(use_converter):
+    signal = LinSignal('BattCurr', 24, [0, 0, 2])
+    encoding_type = LinSignalEncodingType(
+        "BattCurrCoding",
+        [PhysicalValue(0, 182272, 0.00390625, -512, "A")]
+    )
+    converters = {}
+    if use_converter:
+        converters["BattCurr"] = encoding_type
+    else:
+        signal.encoding_type = encoding_type
+
+    frame = LinUnconditionalFrame(0x20, "LinStatus", 3, {0: signal})
+    raw = {"BattCurr": [1, 1, 1]}
+    encoded_expected = bytearray([1, 1, 1])
+    decoded_expected = {"BattCurr": [-511.99609375, -511.99609375, -511.99609375]}
+    encoded_raw = frame.encode_raw(raw)
+    assert encoded_raw == encoded_expected
+
+    decoded = frame.decode(encoded_raw, converters)
+    assert decoded == decoded_expected
+
+    encoded = frame.encode(decoded, converters)
+    decoded_raw = frame.decode_raw(encoded)
+    assert decoded_raw == raw
+
+@pytest.mark.unit
+def test_encode_decode_array_no_converter():
+    signal = LinSignal('BattCurr', 24, [0, 0, 2])
+    frame = LinUnconditionalFrame(0x20, "LinStatus", 3, {0: signal})
+    raw = {"BattCurr": [1, 1, 1]}
+    encoded_expected = bytearray([1, 1, 1])
+
+    encoded = frame.encode(raw)
+    assert encoded == encoded_expected
+
+    decoded = frame.decode(encoded)
+    assert decoded == raw
 
 @pytest.mark.unit
 class TestLinUnconditionalFrameDecodingRaw:


### PR DESCRIPTION
## Brief

- Please provide brief information, what this pull request provides or fixes, possibly in a list format
Propose a fix for the issue https://github.com/c4deszes/ldfparser/issues/119.

### Checklist

<!-- Use the checklist below to ensure the changes are correct and consistent
     with the rest of the codebase.
 -->

- [ ] Add relevant labels to the Pull Request
- [ ] Review test results and code coverage
  - [ ] Review snapshot test results for deviations
- [ ] Review code changes
  - [ ] Create relevant test scenarios
  - [ ] Update examples
  - [ ] Update JSON schema
- [ ] Update documentation
  - [ ] Update examples in README
- [ ] Update changelog
- [ ] Update version number

## Resolves

<!--
     Use the syntax: "Fixes #42" or "Resolves #42" to automatically link to issues.
 -->

Fixes #119.

+ Describe the bug or feature and link to relevant issues

Update decode/encode function to support signals with list type init values, as in `  BSBatt2Current: 24, {0, 0, 2}, ECU, GWM ;`. 
 
https://github.com/c4deszes/ldfparser/issues/119
## Evidence

<!-- This section is meant to provide proof that the PR is correct.
     Here you should note if a change will possibly break existing usage of the library
     or how new features are tested.
 -->

+ Analyze how the change might impact existing code

+ Provide evidence that the feature is tested and covered properly
Added unit test.
